### PR TITLE
comms: fix some format specifiers

### DIFF
--- a/firmware/drivers/comms/comms_class.c
+++ b/firmware/drivers/comms/comms_class.c
@@ -146,7 +146,7 @@ int comms_backend_submit_command(struct comm_backend_driver *backend,
 	// Error out.
 	if (!handling_class->command_verbs && !handling_class->command_handler) {
 		pr_warning(
-				"comms: backend %s submttied a command for class %d, which has neither\n"
+				"comms: backend %s submttied a command for class %s, which has neither\n"
 				"a command handler nor verb handlers!\n",
 				backend->name, handling_class->name);
 		return EINVAL;

--- a/firmware/drivers/comms/comms_class.c
+++ b/firmware/drivers/comms/comms_class.c
@@ -137,7 +137,7 @@ int comms_backend_submit_command(struct comm_backend_driver *backend,
 
 	// If we couldn't find a handling class.
 	if (!handling_class) {
-		pr_warning("comms: backend %s submitted a command for an unknown class %d (%x)\n",
+		pr_warning("comms: backend %s submitted a command for an unknown class %" PRIu32 " (%" PRIx32 ")\n",
 				backend->name, trans->class_number, trans->class_number);
 		return EINVAL;
 	}
@@ -171,7 +171,7 @@ int comms_backend_submit_command(struct comm_backend_driver *backend,
 
 	// If we couldn't find any handler, abort.
 	if (!found_handler) {
-		pr_warning("comms: backend %s submttied a command class %s with an unhandled verb %d / %x\n",
+		pr_warning("comms: backend %s submttied a command class %s with an unhandled verb %" PRIu32 " / %" PRIx32 "\n",
 				backend->name, handling_class->name, trans->verb, trans->verb);
 		return EINVAL;
 	}

--- a/firmware/drivers/comms/utils.c
+++ b/firmware/drivers/comms/utils.c
@@ -42,7 +42,7 @@
 		type value = *target; \
 		\
 		if (sizeof(type) > trans->data_in_remaining) { \
-			pr_comms_error(trans, "not enough data provided to read %s response (%d byte(s) left)\n", #type, \
+			pr_comms_error(trans, "not enough data provided to read %s response (%" PRIu32 " byte(s) left)\n", #type, \
 					trans->data_in_remaining); \
 			trans->data_in_status |= COMMS_PARSE_UNDERRUN; \
 			return (type)0; \
@@ -147,7 +147,7 @@ void *comms_response_reserve_space(struct command_transaction *trans, uint32_t s
 	uint32_t available_length = trans->data_out_max_length - trans->data_out_length;
 
 	if (size > available_length) {
-		pr_comms_error(trans, "not enough space to reserve %d requested bytes\n", size);
+		pr_comms_error(trans, "not enough space to reserve %" PRIu32 " requested bytes\n", size);
 		trans->data_out_status = COMMS_PARSE_OVERRUN;
 		return NULL;
 	}


### PR DESCRIPTION
In particular, a few for fixed-width integer types, but also one where a string was specified with `%d` instead of `%s`.